### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.8
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 # CHANGELOG
 
 ## 0.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ncmb
-version: 0.1.7
+version: 0.1.8
 description: >-
   Dart and Flutter library for Nifcloud mobile backend(NCMB). Nifcloud mobile backend is a web service of mBaaS.
 homepage: https://github.com/NCMBMania/ncmb-dart
@@ -10,7 +10,7 @@ environment:
 dependencies:
   crypto: ^2.1.3
   intl: ^0.16.1
-  package_info: ^0.4.0+13
+  package_info: '>=0.4.0+13 <2.0.0'
   plain_notification_token: ^0.0.1
   notification_reactor: ^0.0.3+1
   dio: ^3.0.8


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).