### PR TITLE
Fix notInArray Query Method

### DIFF
--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -171,7 +171,7 @@ class NCMBQuery {
   /// [key] フィールド名
   /// [value] 検索する値
   void notInArray(String key, Object value) {
-    setOperand(key, value, ope: '\$notInArray');
+    setOperand(key, value, ope: '\$ninArray');
   }
 
   /// 指定したフィールドの値が、指定した位置情報の近い順にデータを取得する


### PR DESCRIPTION
QueryのnotInArrayメソッドについて、オペレータが違っているため修正をしました。  


参考：https://mbaas.nifcloud.com/doc/current/rest/common/query.html#配列の検索