### PR TITLE
Fix description about order method

### DIFF
--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -313,7 +313,7 @@ class NCMBQuery {
 
   /// 検索結果を、指定したフィールドでソートする
   /// [key] フィールド名
-  /// [descending] 並び順（true: 昇順、false: 降順）。省略時は昇順
+  /// [descending] 並び順（true: 降順、false: 昇順）。省略時は降順
   void order(String key, {bool descending = true}) {
     var symbol = descending == true ? '-' : '';
     if (!_queries.containsKey('order')) {


### PR DESCRIPTION
Queryのorderメソッドについて、説明文の降順・昇順が逆になっていたため修正しました。

参考：[REST API リファレンス > クエリの指定方法 ](https://mbaas.nifcloud.com/doc/current/rest/common/query.html)より、`その他クエリのキーについて` > `orderキーの詳細`
> 並び順を指定する
(降順はマイナス付与)